### PR TITLE
✨ Add mockk-junit5 module

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Patterns for [MockK](https://mockk.io) ([GitHub](https://github.com/mockk/mockk)
 | name |
 | -- |
 | [`mockk-junit4`](junit4) |
+| [`mockk-junit5`](junit5) |
 
 For installation and usage: see the readme in the module dir.
 For changes and release notes: see the changelog in the module dir.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,12 +7,3 @@ allprojects {
         mavenCentral()
     }
 }
-
-tasks {
-    compileKotlin {
-        kotlinOptions.jvmTarget = "1.8"
-    }
-    compileTestKotlin {
-        kotlinOptions.jvmTarget = "1.8"
-    }
-}

--- a/junit4/build.gradle.kts
+++ b/junit4/build.gradle.kts
@@ -20,6 +20,15 @@ dependencies {
     implementation("junit:junit:4.13")
 }
 
+tasks {
+    compileKotlin {
+        kotlinOptions.jvmTarget = "1.8"
+    }
+    compileTestKotlin {
+        kotlinOptions.jvmTarget = "1.8"
+    }
+}
+
 java.withSourcesJar()
 
 publishing {

--- a/junit5/CHANGELOG.md
+++ b/junit5/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- JUnit 5 module
+  - `MockkClearExtension` to clear all MockK mocks after each unit test
+  - `MockkUnmockExtension` to unmock all MockK mocks after a test class
+  - `MockkExtension` to automatically apply `MockkClearExtension` and `MockkUnmockExtension`
+- CHANGELOG.md
+- README.md

--- a/junit5/README.md
+++ b/junit5/README.md
@@ -36,7 +36,7 @@ See the JUnit 5 user guide to learn more about [registering extension](https://j
 
 #### `MockkExtension`
 
-Apply this `Extension` to automatically apply `MockkClearExtension` and `MockkUnmockExtension].
+Apply this `Extension` to automatically apply `MockkClearExtension` and `MockkUnmockExtension`.
 These extensions clear all MockK mocks after every unit test and unmock all MockK mocks after the test class.
 
 #### `MockkClearExtension`

--- a/junit5/README.md
+++ b/junit5/README.md
@@ -1,0 +1,48 @@
+# `mockk-junit5`
+
+MockK Patterns for JUnit 5
+
+## Installation
+
+<details open>
+
+<summary>
+Gradle Kotlin DSL
+</summary>
+
+```kotlin
+testImplementation("com.github.erikhuizinga:mockk-junit5:$LATEST_VERSION")
+```
+
+</details>
+
+<details>
+
+<summary>
+Gradle Groovy DSL
+</summary>
+
+```groovy
+testImplementation "com.github.erikhuizinga:mockk-junit5:$LATEST_VERSION"
+```
+
+</details>
+
+## Usage
+
+### MockK JUnit 5 extensions
+
+See the JUnit 5 user guide to learn more about [registering extension](https://junit.org/junit5/docs/5.6.0/user-guide/#extensions-registration). 
+
+#### `MockkExtension`
+
+Apply this `Extension` to automatically apply `MockkClearExtension` and `MockkUnmockExtension].
+These extensions clear all MockK mocks after every unit test and unmock all MockK mocks after the test class.
+
+#### `MockkClearExtension`
+
+Apply this `Extension` to clear all Mockk mocks after each unit test.
+
+#### `MockkUnmockExtension`
+
+Apply this `Extension` to unmock all Mockk mocks after the test class.

--- a/junit5/README.md
+++ b/junit5/README.md
@@ -46,3 +46,7 @@ Apply this `Extension` to clear all Mockk mocks after each unit test.
 #### `MockkUnmockExtension`
 
 Apply this `Extension` to unmock all Mockk mocks after the test class.
+
+### Example
+
+Take a look at [ExampleTestSuite](src/test/kotlin/com/github/erikhuizinga/mockk/junit5/example/ExampleTestSuite.kt) for an example to use `MockkExtension` with an extensive description of the involved MockK and JUnit 5 mechanics.

--- a/junit5/build.gradle.kts
+++ b/junit5/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     id("com.jfrog.bintray") version "1.8.4"
 }
 
-internal val theVersion = "1.0.0-SNAPSHOT"
+internal val theVersion = "1.0.0-alpha"
 internal val theArtifactId = "mockk-junit5"
 internal val thePublication = "${theArtifactId}Publication"
 internal val theGroup = "com.github.erikhuizinga"

--- a/junit5/build.gradle.kts
+++ b/junit5/build.gradle.kts
@@ -1,0 +1,56 @@
+import com.jfrog.bintray.gradle.BintrayExtension
+
+plugins {
+    kotlin("jvm")
+    `maven-publish`
+    id("com.jfrog.bintray") version "1.8.4"
+}
+
+internal val theVersion = "1.0.0-SNAPSHOT"
+internal val theArtifactId = "mockk-junit5"
+internal val thePublication = "${theArtifactId}Publication"
+internal val theGroup = "com.github.erikhuizinga"
+
+group = theGroup
+version = theVersion
+
+dependencies {
+    implementation(kotlin("stdlib-jdk8"))
+    implementation("io.mockk:mockk:1.9.3")
+    implementation("org.junit.jupiter:junit-jupiter:5.6.0")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}
+
+java.withSourcesJar()
+
+publishing {
+    publications {
+        create<MavenPublication>(thePublication) {
+            groupId = theGroup
+            artifactId = theArtifactId
+            version = theVersion
+            from(components["java"])
+        }
+    }
+}
+
+configure<BintrayExtension> {
+    dryRun = true
+    user = properties["bintrayUser"] as String
+    key = properties["bintrayKey"] as String
+    pkg.apply {
+        version.apply {
+            name = theVersion
+            vcsTag = theVersion
+        }
+        repo = "maven"
+        name = theArtifactId
+        userOrg = "erikhuizinga"
+        setLicenses("Apache-2.0")
+        vcsUrl = "https://github.com/erikhuizinga/mockk-patterns.git"
+    }
+    setPublications(thePublication)
+}

--- a/junit5/build.gradle.kts
+++ b/junit5/build.gradle.kts
@@ -20,6 +20,15 @@ dependencies {
     implementation("org.junit.jupiter:junit-jupiter:5.6.0")
 }
 
+tasks {
+    compileKotlin {
+        kotlinOptions.jvmTarget = "1.8"
+    }
+    compileTestKotlin {
+        kotlinOptions.jvmTarget = "1.8"
+    }
+}
+
 tasks.test {
     useJUnitPlatform()
 }

--- a/junit5/src/main/kotlin/com/github/erikhuizinga/mockk/junit5/MockkExtension.kt
+++ b/junit5/src/main/kotlin/com/github/erikhuizinga/mockk/junit5/MockkExtension.kt
@@ -1,0 +1,14 @@
+package com.github.erikhuizinga.mockk.junit5
+
+import org.junit.jupiter.api.extension.AfterAllCallback
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.Extension
+
+/**
+ * Apply this [Extension] to automatically apply [MockkClearExtension] and [MockkUnmockExtension].
+ * These extensions clear all MockK mocks after every unit test and unmock all MockK mocks after the
+ * test class.
+ */
+class MockkExtension :
+    AfterEachCallback by MockkClearExtension(),
+    AfterAllCallback by MockkUnmockExtension()

--- a/junit5/src/main/kotlin/com/github/erikhuizinga/mockk/junit5/MockkExtensions.kt
+++ b/junit5/src/main/kotlin/com/github/erikhuizinga/mockk/junit5/MockkExtensions.kt
@@ -1,6 +1,8 @@
 package com.github.erikhuizinga.mockk.junit5
 
 import io.mockk.clearAllMocks
+import io.mockk.unmockkAll
+import org.junit.jupiter.api.extension.AfterAllCallback
 import org.junit.jupiter.api.extension.AfterEachCallback
 import org.junit.jupiter.api.extension.Extension
 import org.junit.jupiter.api.extension.ExtensionContext
@@ -10,4 +12,11 @@ import org.junit.jupiter.api.extension.ExtensionContext
  */
 class MockkClearExtension : AfterEachCallback {
     override fun afterEach(context: ExtensionContext?) = clearAllMocks()
+}
+
+/**
+ * Apply this [Extension] to unmock all Mockk mocks after the test class.
+ */
+class MockkUnmockExtension : AfterAllCallback {
+    override fun afterAll(context: ExtensionContext?) = unmockkAll()
 }

--- a/junit5/src/main/kotlin/com/github/erikhuizinga/mockk/junit5/MockkExtensions.kt
+++ b/junit5/src/main/kotlin/com/github/erikhuizinga/mockk/junit5/MockkExtensions.kt
@@ -1,0 +1,13 @@
+package com.github.erikhuizinga.mockk.junit5
+
+import io.mockk.clearAllMocks
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.Extension
+import org.junit.jupiter.api.extension.ExtensionContext
+
+/**
+ * Apply this [Extension] to clear all Mockk mocks after each unit test.
+ */
+class MockkClearExtension : AfterEachCallback {
+    override fun afterEach(context: ExtensionContext?) = clearAllMocks()
+}

--- a/junit5/src/test/kotlin/com/github/erikhuizinga/mockk/junit5/example/ExampleTestSuite.kt
+++ b/junit5/src/test/kotlin/com/github/erikhuizinga/mockk/junit5/example/ExampleTestSuite.kt
@@ -1,0 +1,81 @@
+package com.github.erikhuizinga.mockk.junit5.example
+
+import com.github.erikhuizinga.mockk.junit5.MockkExtension
+import com.github.erikhuizinga.mockk.junit5.example.ExampleTestSuite.ExampleMockkExtensionTest
+import com.github.erikhuizinga.mockk.junit5.example.ExampleTestSuite.YourObjectIsNoLongerMockedTest
+import io.mockk.MockKException
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.verify
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.extension.ExtendWith
+
+/**
+ * This will be mocked in the example.
+ */
+object YourObject
+
+/**
+ * In this test class the order of nested classes and unit tests is fixed for the example's
+ * purposes.
+ *
+ * [@ExtendWith(MockkExtension::class)][MockkExtension] ensures all MockK mock state is cleared between unit tests
+ * and all mocks are unmocked between test classes.
+ *
+ * The first test class [ExampleMockkExtensionTest] runs.
+ * First we mock [YourObject].
+ * Because mocking may be expensive and/or slow, we only do this once by using
+ * [TestInstance.Lifecycle.PER_CLASS] and [@BeforeAll][BeforeAll].
+ *
+ * Then the unit tests in `ExampleMockkExtensionTest` run.
+ * Test 1 mocks [YourObject.toString] and then asserts and verified this.
+ * Test 2 is in the same test class, so `YourObject` is still mocked, but any mock state from test 1
+ * should not leak into test 2 (i.e. the mock should be cleared); this is tested in test 2.
+ *
+ * The next test class [YourObjectIsNoLongerMockedTest] should not be influenced by the first test
+ * class and its unit tests.
+ * Test 3 asserts and verifies this.
+ * However, the verification cannot be done, because `YourObject` is no longer a mock.
+ * Instead, MockK throws a [MockKException] and this is asserted.
+ */
+class ExampleTestSuite {
+    private val string = "string"
+
+    @ExtendWith(MockkExtension::class) // From mockk-junit5, remove this to leak mock state!
+    @Nested
+    @TestMethodOrder(MethodOrderer.Alphanumeric::class)
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    inner class ExampleMockkExtensionTest {
+        @BeforeAll
+        fun `before all`() {
+            // This mock should not leak between classes and unit tests!
+            mockkObject(YourObject)
+        }
+
+        @Test
+        fun `test 1`() {
+            every { YourObject.toString() } returns string // Mock toString
+            assertEquals(string, YourObject.toString())
+            verify(exactly = 1) { YourObject.toString() }
+        }
+
+        @Test
+        fun `test 2`() {
+            assertNotEquals(string, YourObject.toString()) // toString is no longer mocked!
+            verify(exactly = 1) { YourObject.toString() } // YourObject still is mocked!
+        }
+    }
+
+    @Nested
+    inner class YourObjectIsNoLongerMockedTest {
+        @Test
+        fun `test 3`() {
+            assertNotEquals(string, YourObject.toString()) // toString is no longer mocked!
+            assertThrows<MockKException> {
+                verify(exactly = 1) { YourObject.toString() } // YourObject is no longer mocked!
+            }
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,2 +1,2 @@
 rootProject.name = "mockk-patterns"
-include("junit4")
+include("junit4", "junit5")


### PR DESCRIPTION
Closes #1.

@dragneelfps could you try this version and leave a review (because you opened #1)?

I'm publishing this version ASAP as mockk-junit5:1.0.0-alpha to JCenter, but it might take hours for it to be accepted. Until then, you can get it using:

```groovy
repositories {
    maven {
        url  "https://dl.bintray.com/erikhuizinga/maven" 
    }
}
```

and

```groovy
testImplementation "com.github.erikhuizinga:mockk-junit5:1.0.0-alpha"
```