### PR TITLE
Configure publishing to Maven Central

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
-# Created by https://www.gitignore.io/api/java,linux,macos,gradle,kotlin,windows,intellij+all,jetbrains+all
-# Edit at https://www.gitignore.io/?templates=java,linux,macos,gradle,kotlin,windows,intellij+all,jetbrains+all
+
+# Created by https://www.toptal.com/developers/gitignore/api/gradle,macos,windows,linux,java,kotlin,intellij+all,jetbrains+all
+# Edit at https://www.toptal.com/developers/gitignore?templates=gradle,macos,windows,linux,java,kotlin,intellij+all,jetbrains+all
 
 ### Intellij+all ###
-# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
 # User-specific stuff
@@ -32,6 +33,9 @@
 # When using Gradle or Maven with auto-import, you should exclude module files,
 # since they will be recreated, and may cause churn.  Uncomment if using
 # auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
 # .idea/modules.xml
 # .idea/*.iml
 # .idea/modules
@@ -113,7 +117,7 @@ modules.xml
 hs_err_pid*
 
 ### JetBrains+all ###
-# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
 # User-specific stuff
@@ -128,6 +132,9 @@ hs_err_pid*
 # When using Gradle or Maven with auto-import, you should exclude module files,
 # since they will be recreated, and may cause churn.  Uncomment if using
 # auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
 # .idea/modules.xml
 # .idea/*.iml
 # .idea/modules
@@ -199,7 +206,7 @@ hs_err_pid*
 .LSOverride
 
 # Icon must end with two \r
-Icon
+Icon
 
 # Thumbnails
 ._*
@@ -265,4 +272,7 @@ gradle-app.setting
 ### Gradle Patch ###
 **/build/
 
-# End of https://www.gitignore.io/api/java,linux,macos,gradle,kotlin,windows,intellij+all,jetbrains+all
+# End of https://www.toptal.com/developers/gitignore/api/gradle,macos,windows,linux,java,kotlin,intellij+all,jetbrains+all
+
+local.properties
+

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Patterns for [MockK](https://mockk.io) ([GitHub](https://github.com/mockk/mockk)
 
 | name | latest version |
 | -- | -- |
-| [`mockk-junit4`](junit4) | [![Download](https://api.bintray.com/packages/erikhuizinga/maven/mockk-junit4/images/download.svg)](https://bintray.com/erikhuizinga/maven/mockk-junit4/_latestVersion) |
-| [`mockk-junit5`](junit5) | [![Download](https://api.bintray.com/packages/erikhuizinga/maven/mockk-junit5/images/download.svg)](https://bintray.com/erikhuizinga/maven/mockk-junit5/_latestVersion) |
+| [`mockk-junit4`](junit4) | [![Download from Maven Central](https://img.shields.io/badge/dynamic/xml?color=brightgreen&label=Maven%20Central&prefix=com.github.erikhuizinga:mockk-junit4:&query=.%2F%2Flatest&url=https%3A%2F%2Frepo1.maven.org%2Fmaven2%2Fcom%2Fgithub%2Ferikhuizinga%2Fmockk-junit4%2Fmaven-metadata.xml)](https://search.maven.org/artifact/com.github.erikhuizinga/mockk-junit4) |
+| [`mockk-junit5`](junit5) | [![Download from Maven Central](https://img.shields.io/badge/dynamic/xml?color=darkgreen&label=Maven%20Central&prefix=com.github.erikhuizinga:mockk-junit5:&query=.%2F%2Flatest&url=https%3A%2F%2Frepo1.maven.org%2Fmaven2%2Fcom%2Fgithub%2Ferikhuizinga%2Fmockk-junit5%2Fmaven-metadata.xml)](https://search.maven.org/artifact/com.github.erikhuizinga/mockk-junit5) |
 
 For installation and usage: see the readme in the module dir.
 For changes and release notes: see the changelog in the module dir.

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins { `kotlin-dsl` }
-repositories { jcenter() }
+repositories { mavenCentral() }
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.70")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -2,6 +2,5 @@ plugins { `kotlin-dsl` }
 repositories { jcenter() }
 
 dependencies {
-    implementation("com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4")
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.70")
 }

--- a/buildSrc/src/main/kotlin/PublishConfig.kt
+++ b/buildSrc/src/main/kotlin/PublishConfig.kt
@@ -1,81 +1,14 @@
-import com.jfrog.bintray.gradle.BintrayExtension
-import com.jfrog.bintray.gradle.BintrayPlugin
 import org.gradle.api.Project
-import org.gradle.api.plugins.JavaPlugin
-import org.gradle.api.plugins.JavaPluginExtension
-import org.gradle.api.publish.PublishingExtension
-import org.gradle.api.publish.maven.MavenPublication
-import org.gradle.api.publish.maven.plugins.MavenPublishPlugin
 import org.gradle.kotlin.dsl.apply
-import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.create
-import org.gradle.kotlin.dsl.get
+import org.gradle.kotlin.dsl.extra
 
 fun Project.configurePublishing(
+    name: String,
     version: String,
     artifactId: String
 ) {
-    configureJavaPlugin()
-    val publication = "${artifactId}Publication"
-    configureMavenPublishing(
-        version = version,
-        artifactId = artifactId,
-        publication = publication
-    )
-    configureBintrayPlugin(
-        version = version,
-        artifactId = artifactId,
-        publication = publication
-    )
-}
-
-private fun Project.configureJavaPlugin() {
-    apply<JavaPlugin>()
-    configure<JavaPluginExtension> { withSourcesJar() }
-}
-
-private fun Project.configureMavenPublishing(
-    version: String,
-    artifactId: String,
-    publication: String
-) {
-    apply<MavenPublishPlugin>()
-    configure<PublishingExtension> {
-        publications {
-            create<MavenPublication>(publication) {
-                groupId = "com.github.erikhuizinga"
-                this.artifactId = artifactId
-                this.version = version
-                from(components["java"])
-            }
-        }
-    }
-}
-
-private fun Project.configureBintrayPlugin(
-    version: String,
-    artifactId: String,
-    publication: String
-) {
-    apply<BintrayPlugin>()
-    configure<BintrayExtension> {
-        configure<BintrayExtension> {
-            dryRun = true
-            publish = true
-            user = properties["bintrayUser"] as? String
-            key = properties["bintrayKey"] as? String
-            pkg.apply {
-                this.version.apply {
-                    name = version
-                    vcsTag = "${artifactId}v$version"
-                }
-                repo = "maven"
-                name = artifactId
-                userOrg = "erikhuizinga"
-                setLicenses("Apache-2.0")
-                vcsUrl = "https://github.com/erikhuizinga/mockk-patterns.git"
-            }
-            setPublications(publication)
-        }
-    }
+    extra["NAME"] = name
+    extra["VERSION"] = version
+    extra["ARTIFACT_ID"] = artifactId
+    apply(from = "${rootProject.rootDir}/ossrh-publishing.gradle")
 }

--- a/junit4/README.md
+++ b/junit4/README.md
@@ -1,4 +1,4 @@
-[![Download](https://api.bintray.com/packages/erikhuizinga/maven/mockk-junit4/images/download.svg)](https://bintray.com/erikhuizinga/maven/mockk-junit4/_latestVersion)
+[![Download from Maven Central](https://img.shields.io/badge/dynamic/xml?color=brightgreen&label=Maven%20Central&prefix=com.github.erikhuizinga:mockk-junit4:&query=.%2F%2Flatest&url=https%3A%2F%2Frepo1.maven.org%2Fmaven2%2Fcom%2Fgithub%2Ferikhuizinga%2Fmockk-junit4%2Fmaven-metadata.xml)](https://search.maven.org/artifact/com.github.erikhuizinga/mockk-junit4)
 
 # `mockk-junit4`
 

--- a/junit4/README.md
+++ b/junit4/README.md
@@ -14,9 +14,7 @@ Artifacts are hosted on the [Maven Central repository](https://search.maven.org/
 repositories {
     mavenCentral()
 }
-```
 
-```kotlin
 dependencies {
     testImplementation("com.github.erikhuizinga:mockk-junit4:$LATEST_VERSION")
 }

--- a/junit4/README.md
+++ b/junit4/README.md
@@ -6,29 +6,21 @@ MockK Patterns for JUnit 4
 
 ## Installation
 
-<details open>
+Artifacts are hosted on the [Maven Central repository](https://search.maven.org/artifact/com.github.erikhuizinga/mockk-junit4).
 
-<summary>
-Gradle Kotlin DSL
-</summary>
+### Gradle Installation
 
 ```kotlin
-testImplementation("com.github.erikhuizinga:mockk-junit4:$LATEST_VERSION")
+repositories {
+    mavenCentral()
+}
 ```
 
-</details>
-
-<details>
-
-<summary>
-Gradle Groovy DSL
-</summary>
-
-```groovy
-testImplementation "com.github.erikhuizinga:mockk-junit4:$LATEST_VERSION"
+```kotlin
+dependencies {
+    testImplementation("com.github.erikhuizinga:mockk-junit4:$LATEST_VERSION")
+}
 ```
-
-</details>
 
 ## Usage
 

--- a/junit4/build.gradle.kts
+++ b/junit4/build.gradle.kts
@@ -10,6 +10,7 @@ tasks.test {
 }
 
 configurePublishing(
+    name = "MockK Patterns for JUnit 4",
     version = "1.0.0",
     artifactId = "mockk-junit4"
 )

--- a/junit5/README.md
+++ b/junit5/README.md
@@ -6,29 +6,21 @@ MockK Patterns for JUnit 5
 
 ## Installation
 
-<details open>
+Artifacts are hosted on the [Maven Central repository](https://search.maven.org/artifact/com.github.erikhuizinga/mockk-junit5).
 
-<summary>
-Gradle Kotlin DSL
-</summary>
+### Gradle Installation
 
 ```kotlin
-testImplementation("com.github.erikhuizinga:mockk-junit5:$LATEST_VERSION")
+repositories {
+    mavenCentral()
+}
 ```
 
-</details>
-
-<details>
-
-<summary>
-Gradle Groovy DSL
-</summary>
-
-```groovy
-testImplementation "com.github.erikhuizinga:mockk-junit5:$LATEST_VERSION"
+```kotlin
+dependencies {
+    testImplementation("com.github.erikhuizinga:mockk-junit5:$LATEST_VERSION")
+}
 ```
-
-</details>
 
 ## Usage
 

--- a/junit5/README.md
+++ b/junit5/README.md
@@ -1,4 +1,4 @@
-[![Download](https://api.bintray.com/packages/erikhuizinga/maven/mockk-junit5/images/download.svg)](https://bintray.com/erikhuizinga/maven/mockk-junit5/_latestVersion)
+[![Download from Maven Central](https://img.shields.io/badge/dynamic/xml?color=darkgreen&label=Maven%20Central&prefix=com.github.erikhuizinga:mockk-junit5:&query=.%2F%2Flatest&url=https%3A%2F%2Frepo1.maven.org%2Fmaven2%2Fcom%2Fgithub%2Ferikhuizinga%2Fmockk-junit5%2Fmaven-metadata.xml)](https://search.maven.org/artifact/com.github.erikhuizinga/mockk-junit5)
 
 # `mockk-junit5`
 

--- a/junit5/README.md
+++ b/junit5/README.md
@@ -14,9 +14,7 @@ Artifacts are hosted on the [Maven Central repository](https://search.maven.org/
 repositories {
     mavenCentral()
 }
-```
 
-```kotlin
 dependencies {
     testImplementation("com.github.erikhuizinga:mockk-junit5:$LATEST_VERSION")
 }

--- a/junit5/build.gradle.kts
+++ b/junit5/build.gradle.kts
@@ -5,6 +5,7 @@ dependencies {
 tasks.test { useJUnitPlatform() }
 
 configurePublishing(
+    name = "MockK Patterns for JUnit 5",
     version = "2.0.0",
     artifactId = "mockk-junit5"
 )

--- a/ossrh-publishing.gradle
+++ b/ossrh-publishing.gradle
@@ -1,0 +1,80 @@
+apply plugin: 'java'
+apply plugin: 'maven'
+apply plugin: 'signing'
+
+def theArtifactID = ext.ARTIFACT_ID
+def theName = ext.NAME
+def theVersion = ext.VERSION
+
+java {
+    withJavadocJar()
+    withSourcesJar()
+}
+
+javadocJar {
+    archiveClassifier.set('javadoc')
+    from javadoc
+}
+
+sourcesJar {
+    archiveClassifier.set('sources')
+    from sourceSets.main.allSource
+}
+
+artifacts {
+    archives sourcesJar, javadocJar
+}
+
+signing {
+    sign configurations.archives
+}
+
+group = "com.github.erikhuizinga"
+archivesBaseName = theArtifactID
+version = theVersion
+
+uploadArchives {
+    repositories {
+        mavenDeployer {
+            beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+
+            repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+                authentication(userName: ossrhUsername, password: ossrhPassword)
+            }
+
+            snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
+                authentication(userName: ossrhUsername, password: ossrhPassword)
+            }
+
+            pom.project {
+                name = theName
+                artifactId theArtifactID
+                description theName
+                url 'https://github.com/erikhuizinga/mockk-patterns'
+
+                packaging 'jar'
+
+                scm {
+                    connection 'scm:git:git://github.com/erikhuizinga/mockk-patterns.git'
+                    developerConnection 'scm:git:ssh://github.com/erikhuizinga/mockk-patterns.git'
+                    url 'https://github.com/erikhuizinga/mockk-patterns/tree/master'
+                }
+
+                licenses {
+                    license {
+                        name 'The Apache License, Version 2.0'
+                        url 'http://www.apache.org/licenses/LICENSE-2.0'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id 'erikhuizinga'
+                        name 'Erik Huizinga'
+                        email 'huizinga.erik@gmail.com'
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ossrh-publishing.gradle
+++ b/ossrh-publishing.gradle
@@ -38,6 +38,9 @@ uploadArchives {
         mavenDeployer {
             beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
+            def ossrhUsername = findProperty('ossrhUsername')
+            def ossrhPassword = findProperty('ossrhPassword')
+
             repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
                 authentication(userName: ossrhUsername, password: ossrhPassword)
             }


### PR DESCRIPTION
JCenter is being shut down, so now let's publish to Maven Central.

TODO

- [x] Configure publishing to Maven Central
- [x] Upload artifacts to staging repo
- [x] Close staging repo
- [x] Release repo
- [x] Request for sync by commenting here: https://issues.sonatype.org/browse/OSSRH-64588
- [x] Update project readme links to published artifacts on https://search.maven.org/